### PR TITLE
feat(pkgs): add sub2api package and NixOS module

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -232,6 +232,27 @@
         },
         "version": "testnet-v1.67.1"
     },
+    "sub2api": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "sub2api",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "Wei-Shaw",
+            "repo": "sub2api",
+            "rev": "v0.1.97",
+            "sha256": "sha256-z8iCqK/AD7DFRNED6lNrZWBz6Us6yB8uo1wlE3S2o2w=",
+            "sparseCheckout": [],
+            "type": "github"
+        },
+        "version": "v0.1.97"
+    },
     "xiaohongshu-mcp": {
         "cargoLock": null,
         "date": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -154,6 +154,17 @@
       sha256 = "sha256-bLytwi6sDSLe45hMvECQAuGnrY7zNEyVGQlExObdiqw=";
     };
   };
+  sub2api = {
+    pname = "sub2api";
+    version = "v0.1.97";
+    src = fetchFromGitHub {
+      owner = "Wei-Shaw";
+      repo = "sub2api";
+      rev = "v0.1.97";
+      fetchSubmodules = false;
+      sha256 = "sha256-z8iCqK/AD7DFRNED6lNrZWBz6Us6yB8uo1wlE3S2o2w=";
+    };
+  };
   xiaohongshu-mcp = {
     pname = "xiaohongshu-mcp";
     version = "v2026.03.09.0605-0e16f4b";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -20,4 +20,5 @@
   fleet = import ./fleet.nix;
   gotrue-supabase = import ./gotrue-supabase;
   xiaohongshu-mcp = import ./xiaohongshu-mcp;
+  sub2api = import ./sub2api;
 }

--- a/modules/sub2api/default.nix
+++ b/modules/sub2api/default.nix
@@ -1,0 +1,241 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.services.sub2api;
+
+  sub2apiPkg = pkgs.callPackage ../../pkgs/sub2api/package.nix { };
+
+  configFile = pkgs.writeText "config.yaml" (
+    builtins.toJSON {
+      server = {
+        host = cfg.host;
+        port = cfg.port;
+        mode = "release";
+      };
+      database = {
+        host = cfg.database.host;
+        port = cfg.database.port;
+        user = cfg.database.user;
+        password = cfg.database.password;
+        dbname = cfg.database.name;
+        sslmode = cfg.database.sslMode;
+      };
+      redis = {
+        host = cfg.redis.host;
+        port = cfg.redis.port;
+        password = cfg.redis.password;
+        db = cfg.redis.db;
+      };
+      jwt = {
+        secret = cfg.jwtSecret;
+        expire_hour = cfg.jwtExpireHour;
+      };
+      totp = {
+        encryption_key = cfg.totpEncryptionKey;
+      };
+      run_mode = cfg.runMode;
+    }
+  );
+in
+{
+  options.services.sub2api = {
+    enable = mkEnableOption "Sub2API - AI API gateway platform";
+
+    package = mkOption {
+      type = types.package;
+      default = sub2apiPkg;
+      description = "Sub2API package to use";
+    };
+
+    host = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = "Host address to listen on";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8080;
+      description = "HTTP port to listen on";
+    };
+
+    runMode = mkOption {
+      type = types.enum [
+        "standard"
+        "simple"
+      ];
+      default = "standard";
+      description = "Run mode (standard or simple)";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "sub2api";
+      description = "User under which sub2api runs";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "sub2api";
+      description = "Group under which sub2api runs";
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/sub2api";
+      description = "Data directory for sub2api";
+    };
+
+    database = {
+      host = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = "PostgreSQL host";
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 5432;
+        description = "PostgreSQL port";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "sub2api";
+        description = "PostgreSQL username";
+      };
+
+      password = mkOption {
+        type = types.str;
+        default = "";
+        description = "PostgreSQL password. Consider using environmentFile instead.";
+      };
+
+      name = mkOption {
+        type = types.str;
+        default = "sub2api";
+        description = "PostgreSQL database name";
+      };
+
+      sslMode = mkOption {
+        type = types.str;
+        default = "disable";
+        description = "PostgreSQL SSL mode";
+      };
+    };
+
+    redis = {
+      host = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = "Redis host";
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 6379;
+        description = "Redis port";
+      };
+
+      password = mkOption {
+        type = types.str;
+        default = "";
+        description = "Redis password";
+      };
+
+      db = mkOption {
+        type = types.int;
+        default = 0;
+        description = "Redis database number";
+      };
+    };
+
+    jwtSecret = mkOption {
+      type = types.str;
+      default = "";
+      description = "JWT secret key. Consider using environmentFile instead.";
+    };
+
+    jwtExpireHour = mkOption {
+      type = types.int;
+      default = 24;
+      description = "JWT token expiration in hours";
+    };
+
+    totpEncryptionKey = mkOption {
+      type = types.str;
+      default = "";
+      description = "TOTP encryption key (32-byte hex). Consider using environmentFile instead.";
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = "Path to environment file with secrets (DATABASE_PASSWORD, JWT_SECRET, TOTP_ENCRYPTION_KEY, etc.)";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.dataDir;
+      createHome = true;
+    };
+
+    users.groups.${cfg.group} = { };
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} -"
+    ];
+
+    systemd.services.sub2api = {
+      description = "Sub2API - AI API gateway platform";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "network-online.target"
+        "postgresql.service"
+        "redis.service"
+      ];
+      wants = [ "network-online.target" ];
+
+      environment = {
+        HOME = cfg.dataDir;
+      };
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = cfg.dataDir;
+        StateDirectory = "sub2api";
+        StateDirectoryMode = "0750";
+
+        ExecStartPre = pkgs.writeShellScript "sub2api-pre-start" ''
+          cp ${configFile} ${cfg.dataDir}/config.yaml
+          chmod 600 ${cfg.dataDir}/config.yaml
+        '';
+
+        ExecStart = "${cfg.package}/bin/sub2api";
+
+        Restart = "always";
+        RestartSec = "10s";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [ cfg.dataDir ];
+        PrivateTmp = true;
+      }
+      // lib.optionalAttrs (cfg.environmentFile != null) {
+        EnvironmentFile = cfg.environmentFile;
+      };
+    };
+  };
+}

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -104,3 +104,7 @@ fetch.github = "BeryJu/korb"
 [xiaohongshu-mcp]
 src.github = "xpzouying/xiaohongshu-mcp"
 fetch.github = "xpzouying/xiaohongshu-mcp"
+
+[sub2api]
+src.github = "Wei-Shaw/sub2api"
+fetch.github = "Wei-Shaw/sub2api"

--- a/overlay.nix
+++ b/overlay.nix
@@ -168,6 +168,9 @@ in
   # Xiaohongshu MCP package
   xiaohongshu-mcp = prev.callPackage ./pkgs/xiaohongshu-mcp/package.nix { };
 
+  # Sub2API package
+  sub2api = prev.callPackage ./pkgs/sub2api/package.nix { };
+
   # FCITX5 fix
   fcitx5-configtool = prev.fcitx5-configtool.overrideAttrs (oldAttrs: {
     propagatedBuildInputs = (oldAttrs.propagatedBuildInputs or [ ]) ++ [ prev.libxcb-cursor ];

--- a/pkgs/sub2api/package.nix
+++ b/pkgs/sub2api/package.nix
@@ -1,0 +1,61 @@
+{
+  pkgs,
+  buildGoModule,
+  buildNpmPackage,
+  lib,
+  ...
+}:
+let
+  sources = import ../../_sources/generated.nix {
+    inherit (pkgs)
+      fetchgit
+      fetchFromGitHub
+      fetchurl
+      dockerTools
+      ;
+  };
+
+  version = sources.sub2api.version;
+
+  frontend = buildNpmPackage {
+    pname = "sub2api-frontend";
+    inherit version;
+    src = "${sources.sub2api.src}/frontend";
+    npmDepsHash = "";
+    installPhase = ''
+      runHook preInstall
+      cp -r dist $out
+      runHook postInstall
+    '';
+  };
+in
+buildGoModule (
+  sources.sub2api
+  // {
+    modRoot = "backend";
+    subPackages = [ "cmd/server" ];
+    vendorHash = "";
+    tags = [ "embed" ];
+    ldflags = [
+      "-s"
+      "-w"
+      "-X main.Version=${version}"
+    ];
+    doCheck = false;
+
+    preBuild = ''
+      cp -r ${frontend} internal/web/dist
+    '';
+
+    postInstall = ''
+      mv $out/bin/server $out/bin/sub2api
+    '';
+
+    meta = with lib; {
+      description = "AI API gateway platform for distributing subscription quotas";
+      homepage = "https://github.com/Wei-Shaw/sub2api";
+      license = licenses.mit;
+      maintainers = [ ];
+    };
+  }
+)


### PR DESCRIPTION
Add Sub2API (AI API gateway platform) with nvfetcher source tracking,
Go+Vue package build, and NixOS service module with PostgreSQL/Redis config.

https://claude.ai/code/session_018XRPmrbU5seEFNqo9cAA6x

## Summary by Sourcery

Add a Sub2API package and corresponding NixOS service module for running the AI API gateway platform with database and cache integration.

New Features:
- Package Sub2API as a Go backend plus Vue frontend application built via Nix.
- Expose a NixOS module to manage the Sub2API service with configurable server, PostgreSQL, Redis, and authentication settings.

Enhancements:
- Integrate Sub2API into the existing nvfetcher and overlay infrastructure for reproducible sourcing and package availability.